### PR TITLE
Fix warnings

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -54,5 +54,5 @@ tests:
     node_color: "black"
 
 vars:
-  truncate_timespan_to: "{{ dbt_utils.current_timestamp() }}"
+  truncate_timespan_to: "{{ dbt.current_timestamp() }}"
   s3_bucket: "s3://dbt-demo-data-2022/jaffle-shop"

--- a/models/metrics/metrics.yml
+++ b/models/metrics/metrics.yml
@@ -7,8 +7,8 @@ metrics:
     model: ref('orders')
     description: "Income from all orders less tax"
 
-    type: sum
-    sql: order_total - tax_paid
+    calculation_method: sum
+    expression: order_total - tax_paid
 
     timestamp: ordered_at
     time_grains: [day, week, month, quarter, year]
@@ -22,8 +22,8 @@ metrics:
     model: ref('orders')
     description: "Number of customers with a sale"
 
-    type: count_distinct
-    sql: customer_id
+    calculation_method: count_distinct
+    expression: customer_id
 
     timestamp: ordered_at
     time_grains: [day, week, month, quarter, year]
@@ -36,8 +36,8 @@ metrics:
     model: ref('orders')
     description: "Total expenses per order"
 
-    type: sum
-    sql: order_cost
+    calculation_method: sum
+    expression: order_cost
 
     timestamp: ordered_at
     time_grains: [day, week, month, quarter, year]
@@ -50,8 +50,8 @@ metrics:
     label: Gross Profit
     description: "Revenue minus expenses"
 
-    type: expression
-    sql: "{{ metric('revenue') }} - {{ metric('expenses') }}"
+    calculation_method: expression
+    expression: "{{ metric('revenue') }} - {{ metric('expenses') }}"
 
     timestamp: ordered_at
     time_grains: [day, week, month, quarter, year]


### PR DESCRIPTION
This PR fixes a handful of warnings. Same changes as these two for Snowflake:
- https://github.com/dbt-labs/coalesce-2022-python-snowflake/pull/1
- https://github.com/dbt-labs/coalesce-2022-python-snowflake/pull/2

### Also

When trying to run this repo locally, I got some error messages relating to column names. I fixed them by making local changes to `models/staging/stg_customers.sql` and `models/staging/stg_orders.sql`. Since I am not sure if this is just an artifact of my local environment, I ~will submit~ submitted those changes in a separate pull request:
https://github.com/dbt-labs/coalesce-2022-python-databricks/pull/2