### PR TITLE
Update column names

### DIFF
--- a/models/staging/stg_customers.sql
+++ b/models/staging/stg_customers.sql
@@ -12,10 +12,10 @@ renamed as (
     select
 
         ----------  ids
-        id as customer_id,
+        customer_id,
 
         ---------- properties
-        name as customer_name
+        customer_name
 
     from source
 

--- a/models/staging/stg_orders.sql
+++ b/models/staging/stg_orders.sql
@@ -15,9 +15,9 @@ renamed as (
     select
 
         ----------  ids
-        id as order_id,
-        store_id as location_id,
-        customer as customer_id,
+        order_id,
+        location_id,
+        customer_id,
 
         ---------- properties
         cast(order_total / 100.0 as float) as order_total,


### PR DESCRIPTION
When trying to run this repo locally, I got the following error messages. I fixed them by making the changes in this PR.

I am not sure if this is just an artifact of my local environment or not. This PR can be closed without merging if these changes are not necessary.

### Error messages
```
01:45:22  Completed with 2 errors and 0 warnings:
01:45:22  
01:45:22  Runtime Error in model stg_customers (models/staging/stg_customers.sql)
01:45:22    [UNRESOLVED_COLUMN] A column or function parameter with name `id` cannot be resolved. Did you mean one of the following? [`source`.`customer_id`, `source`.`lifetime_spend`, `source`.`customer_name`, `source`.`customer_type`, `source`.`first_ordered_at`, `source`.`last_ordered_at`, `source`.`count_lifetime_orders`, `source`.`lifetime_spend_pretax`]; line 29 pos 8
01:45:22  
01:45:22  Runtime Error in model stg_orders (models/staging/stg_orders.sql)
01:45:22    [UNRESOLVED_COLUMN] A column or function parameter with name `id` cannot be resolved. Did you mean one of the following? [`source`.`order_id`, `source`.`tax_paid`, `source`.`subtotal`, `source`.`customer_id`, `source`.`location_id`, `source`.`order_cost`, `source`.`ordered_at`, `source`.`count_items`, `source`.`order_total`, `source`.`is_food_order`, `source`.`is_drink_order`, `source`.`is_first_order`, `source`.`location_name`, `source`.`count_food_items`, `source`.`count_drink_items`, `source`.`customer_order_index`, `source`.`subtotal_food_items`, `source`.`subtotal_drink_items`]; line 32 pos 8
```

### How did you get the data?

Friday of last week:
1. Configured my own databricks cluster in `profiles.yml`
1. Ran the commands below

```shell
dbt deps 
dbt run-operation stage_external_sources 
```